### PR TITLE
nv: add nv cJSON create retry if cJSON_Parse fail

### DIFF
--- a/nv/nv.c
+++ b/nv/nv.c
@@ -124,18 +124,22 @@ void nv_sync(char* key, char* value, uint8_t len)
             nv_log("nv sync, nv read fail\n");
             return;
         }
-    } else {
+    }
+
+    if (!json) {
+        nv_log("cJSON Parse fail: %s\n", cJSON_GetErrorPtr());
+
         cJSON* root = cJSON_CreateObject();
         char* str = cJSON_Print(root);
         json = cJSON_Parse(str);
 
         cJSON_free(str);
         cJSON_Delete(root);
-    }
 
-    if (!json) {
-        nv_log("cJSON Parse fail: %s\n", cJSON_GetErrorPtr());
-        return;
+        if (!json) {
+            nv_log("cJSON Parse fail again: %s\n", cJSON_GetErrorPtr());
+            return;
+        }
     }
 
 #if CONFIG_NV_DEBUG_MOCK_DATA


### PR DESCRIPTION
If the data in the buffer is invalid, cJSON_Parse will fail. 
A new buffer will be created with cJSON_create to ensure that the data can be updated correctly.

Signed-off-by: Junbo Zheng <3273070@qq.com>