### PR TITLE
fix build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,11 @@ option(NV_DEBUG_LOG "nv debug log" ON)
 option(ENABLE_SANITIZER "Enables sanitizer" ON)
 option(NV_DEBUG_MOCK_DATA "nv debug mock data" ON)
 
+set(NV_DATA_BUFFER_SIZE "1024" CACHE STRING "")
+
 set(SOURCE nv/nv.c cJSON/cJSON.c cJSON/cJSON_Utils.c test.c)
-set(NV_DATA_BUFFER_SIZE
-    "1024"
-    CACHE STRING "")
+
+add_compile_options(-Wall -Werror -Wno-format -g)
 
 add_executable(${PROJECT_NAME} ${SOURCE})
 
@@ -29,8 +30,6 @@ endif()
 
 target_compile_definitions(
   ${PROJECT_NAME} PUBLIC -DCONFIG_NV_DATA_BUFFER_SIZE=${NV_DATA_BUFFER_SIZE})
-
-add_compile_options(-Wall -Wextra -Werror -Wno-format -g)
 
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/nv/")
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/cJSON/")

--- a/test.c
+++ b/test.c
@@ -56,7 +56,7 @@ typedef struct {
 
 static nv_t nv = { 0 };
 
-static void cjson_create_item(void)
+__attribute__((unused)) static void cjson_create_item(void)
 {
     cJSON* root = cJSON_CreateObject();
 
@@ -74,7 +74,7 @@ static void cjson_create_item(void)
     cJSON_Delete(root);
 }
 
-static void cjson_add_item(void)
+__attribute__((unused)) static void cjson_add_item(void)
 {
     char json[999]
         = { "{\"name\":\"ZhangSan\",\"age\":20,\"height\":180,\"weight\":60}" };
@@ -313,10 +313,10 @@ int main(void)
 
 //    nv_delete(CONFIG_NV_PATH, NV_KEY_NAME);
 
-    memset(score_str, 0, ARRAY_SIZE(score_str));
-    memset(score_int, 0, ARRAY_SIZE(score_int));
-    memset(score_float, 0, ARRAY_SIZE(score_float));
-    memset(score_double, 0, ARRAY_SIZE(score_double));
+    memset(score_str, 0, sizeof(score_str));
+    memset(score_int, 0, sizeof(score_int));
+    memset(score_float, 0, sizeof(score_float));
+    memset(score_double, 0, sizeof(score_double));
 
     /* clang-format off */
     nv_get(CONFIG_NV_PATH, NV_KEY_AGE,    (char*)&age,    sizeof(age),    NV_DATA_U8);
@@ -338,7 +338,7 @@ int main(void)
     nv_log("temp_double = %f\n", temp_double);
 
     char* score_buf[16] = {0};
-    for (int i = 0; i < ARRAY_SIZE(score_buf); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(score_buf); i++) {
         score_buf[i] = calloc(1, ARRAY_SIZE(score_buf) * sizeof(char));
     }
 
@@ -354,14 +354,14 @@ int main(void)
     nv_log("score float  %f %f\n", score_float[0], score_float[1]);
     nv_log("score double %f %f\n", score_double[0], score_double[1]);
 
-    for (int i = 0; i < ARRAY_SIZE(score_buf); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(score_buf); i++) {
         if (score_buf[i]) {
             free(score_buf[i]);
         }
     }
 
-    memset(ip,  0, ARRAY_SIZE(ip));
-    memset(mac, 0, ARRAY_SIZE(mac));
+    memset(ip,  0, sizeof(ip));
+    memset(mac, 0, sizeof(mac));
 
     /* clang-format off */
     nv_get(CONFIG_NV_PATH, NV_KEY_IP,  (char*)ip,  ARRAY_SIZE(ip),  NV_DATA_IP);


### PR DESCRIPTION
fix build warnings
```
➜  /Users/junbozheng/project/cNV git:(master) ✗ cmake --build build -j16
[ 20%] Building C object CMakeFiles/cNV.dir/cJSON/cJSON_Utils.c.o
[ 60%] Building C object CMakeFiles/cNV.dir/test.c.o
[ 60%] Building C object CMakeFiles/cNV.dir/cJSON/cJSON.c.o
[ 80%] Building C object CMakeFiles/cNV.dir/nv/nv.c.o
/Users/junbozheng/project/cNV/nv/nv.c:100:32: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
            json = cJSON_Parse(nv_buffer);
                               ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:148:47: note: passing argument to parameter 'value' here
CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
                                              ^
/Users/junbozheng/project/cNV/nv/nv.c:244:17: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
        sprintf(nv_buffer, "%d.%d.%d.%d", *((uint32_t *)value),
                ^~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/secure/_stdio.h:47:28: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                           ^~~
/Users/junbozheng/project/cNV/nv/nv.c:248:44: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
            cJSON_SetValuestring(key_item, nv_buffer);
                                           ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:280:69: note: passing argument to parameter 'valuestring' here
CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
                                                                    ^
/Users/junbozheng/project/cNV/nv/nv.c:250:48: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
            cJSON_AddStringToObject(json, key, nv_buffer);
                                               ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:269:112: note: passing argument to parameter 'string' here
CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
                                                                                                               ^
/Users/junbozheng/project/cNV/nv/nv.c:255:17: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
        sprintf(nv_buffer, "%d-%d-%d-%d-%d-%d", *((uint32_t *)value),
                ^~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/secure/_stdio.h:47:28: note: expanded from macro 'sprintf'
  __builtin___sprintf_chk (str, 0, __darwin_obsz(str), __VA_ARGS__)
                           ^~~
/Users/junbozheng/project/cNV/nv/nv.c:261:44: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
            cJSON_SetValuestring(key_item, nv_buffer);
                                           ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:280:69: note: passing argument to parameter 'valuestring' here
CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
                                                                    ^
/Users/junbozheng/project/cNV/nv/nv.c:263:48: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
            cJSON_AddStringToObject(json, key, nv_buffer);
                                               ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:269:112: note: passing argument to parameter 'string' here
CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
                                                                                                               ^
/Users/junbozheng/project/cNV/nv/nv.c:297:31: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
    cJSON* json = cJSON_Parse(nv_buffer);
                              ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:148:47: note: passing argument to parameter 'value' here
CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
                                              ^
/Users/junbozheng/project/cNV/nv/nv.c:289:64: error: unused parameter 'len' [-Werror,-Wunused-parameter]
bool nv_get(const char* file, char* key, char* value, uint32_t len,
                                                               ^
/Users/junbozheng/project/cNV/test.c:341:23: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
    for (int i = 0; i < ARRAY_SIZE(score_buf); i++) {
                    ~ ^ ~~~~~~~~~~~~~~~~~~~~~/Users/junbozheng/project/cNV/nv/nv.c
:348:32: error: /Users/junbozheng/project/cNV/test.c:357comparison of integers of different signs: 'uint32_t' (aka 'unsigned int') and 'int' [-Werror,-Wsign-compare]:23
: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]        for (uint32_t i = 0; i < size; i++) {

                             ~ ^ ~~~~
    for (int i = 0; i < ARRAY_SIZE(score_buf); i++) {
                    ~ ^ ~~~~~~~~~~~~~~~~~~~~~
/Users/junbozheng/project/cNV/nv/nv.c:400:31: error: passing 'uint8_t[1024]' (aka 'unsigned char[1024]') to parameter of type 'const char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign]
    cJSON* json = cJSON_Parse(nv_buffer);
                              ^~~~~~~~~
/Users/junbozheng/project/cNV/cJSON/cJSON.h:148:47: note: passing argument to parameter 'value' here
CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
                                              ^
2 errors generated.
11 errors generated.
make[2]: *** [CMakeFiles/cNV.dir/nv/nv.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/cNV.dir/test.c.o] Error 1
make[1]: *** [CMakeFiles/cNV.dir/all] Error 2
make: *** [all] Error 2
```

Signed-off-by: Junbo Zheng <3273070@qq.com>